### PR TITLE
fix: add SMTP outbound rules for email sending in network policy

### DIFF
--- a/apps/express-server/server.js
+++ b/apps/express-server/server.js
@@ -87,4 +87,3 @@ if (process.env.NODE_ENV !== 'test') {
 
 export default app;
 // apps/express-server/server.js
-// This is the main entry point for the Express server.

--- a/manifests/prod/express-network-policy.yaml
+++ b/manifests/prod/express-network-policy.yaml
@@ -28,6 +28,13 @@ spec:
     ports:
     - protocol: TCP
       port: 443
+  # Allow SMTP outbound for email sending
+  - to: []
+    ports:
+    - protocol: TCP
+      port: 587  # Office 365 SMTP
+    - protocol: TCP
+      port: 465  # Alternative SMTP over SSL
   # FIXED: More permissive ingress rules
   ingress:
   # Allow from ingress-nginx namespace (multiple possible label selectors)


### PR DESCRIPTION
found a gap in my testing, the next pr, will be making the same network policies locally, as i do in prod.  let's see if this fixes it for now.  good security tho!