### PR TITLE
fix: update leaderboard to show sidebet

### DIFF
--- a/docs/api/rounds/GET_rounds_id_leaderboard.md
+++ b/docs/api/rounds/GET_rounds_id_leaderboard.md
@@ -1,6 +1,6 @@
 # GET /api/rounds/:id/leaderboard
 
-Get real-time leaderboard for a round with player rankings, scores, and skins information.
+Get real-time leaderboard for a round with player rankings, scores, skins information, and side bet summaries.
 
 ## Endpoint
 ```
@@ -42,8 +42,12 @@ GET /api/rounds/:id/leaderboard
       "holesCompleted": 6,
       "currentHole": 7,
       "skinsWon": 0,
-      "netGain": "0.00",
-      "netGain": "0.00"
+      "moneyIn": 0,
+      "moneyOut": 0,
+      "total": 0,
+      "sideBetsWon": 1,
+      "sideBetsNetGain": 25.00,
+      "overallNetGain": 25.00
     },
     {
       "playerId": "550e8400-e29b-41d4-a716-446655440001",
@@ -57,7 +61,12 @@ GET /api/rounds/:id/leaderboard
       "holesCompleted": 5,
       "currentHole": 6,
       "skinsWon": 0,
-      "netGain": "0.00"
+      "moneyIn": 0,
+      "moneyOut": 0,
+      "total": 0,
+      "sideBetsWon": 0,
+      "sideBetsNetGain": -15.00,
+      "overallNetGain": -15.00
     }
   ],
   "roundSettings": {
@@ -83,7 +92,12 @@ Each player object contains:
 - `holesCompleted` (number): Number of holes with scores recorded
 - `currentHole` (number): Next hole number to play (highest completed + 1)
 - `skinsWon` (number): Number of skins won (real-time calculation when skins are enabled)
-- `netGain` (string): Net profit/loss from skins game (money won minus total pot contribution)
+- `moneyIn` (number): Money won from skins game
+- `moneyOut` (number): Money owed/paid from skins game
+- `total` (number): Net skins money (moneyIn + moneyOut)
+- `sideBetsWon` (number): Number of side bets won by this player
+- `sideBetsNetGain` (number): Net profit/loss from all side bets (positive = profit, negative = loss)
+- `overallNetGain` (number): Combined net gain from skins and side bets (total + sideBetsNetGain)
 
 #### Round Settings
 - `skinsEnabled` (boolean): Whether skins game is enabled for this round
@@ -162,7 +176,12 @@ curl -X GET \
       "holesCompleted": 0,
       "currentHole": 1,
       "skinsWon": 0,
-      "netGain": "0.00"
+      "moneyIn": 0,
+      "moneyOut": 0,
+      "total": 0,
+      "sideBetsWon": 0,
+      "sideBetsNetGain": 0,
+      "overallNetGain": 0
     }
   ],
   "roundSettings": {
@@ -189,7 +208,12 @@ curl -X GET \
       "holesCompleted": 5,
       "currentHole": 6,
       "skinsWon": 3,
-      "netGain": "-5.00"
+      "moneyIn": 15,
+      "moneyOut": -20,
+      "total": -5,
+      "sideBetsWon": 2,
+      "sideBetsNetGain": 30.00,
+      "overallNetGain": 25.00
     },
     {
       "playerId": "550e8400-e29b-41d4-a716-446655440000",
@@ -203,7 +227,12 @@ curl -X GET \
       "holesCompleted": 5,
       "currentHole": 6,
       "skinsWon": 0,
-      "netGain": "-12.50"
+      "moneyIn": 0,
+      "moneyOut": -12.5,
+      "total": -12.5,
+      "sideBetsWon": 0,
+      "sideBetsNetGain": -20.00,
+      "overallNetGain": -32.50
     }
   ],
   "roundSettings": {
@@ -217,11 +246,11 @@ curl -X GET \
 ## Notes
 
 ### Skins Integration
-This endpoint now includes **real-time skins calculation** when skins are enabled:
+This endpoint includes **real-time skins calculation** when skins are enabled:
 
 - **Real-time Calculation**: Skins are calculated dynamically based on current scores
   - `skinsWon` shows actual skins won by each player
-  - `netGain` displays profit/loss for each player (money won minus total pot contribution)
+  - `moneyIn`/`moneyOut`/`total` display profit/loss for each player
   - `currentCarryOver` displays any skins waiting to be won due to ties
   - Calculations respect the round's starting hole order
   - Carry-over logic automatically accumulates skins from tied holes
@@ -229,6 +258,21 @@ This endpoint now includes **real-time skins calculation** when skins are enable
 - **Graceful Degradation**: If skins calculation encounters issues:
   - Leaderboard continues to function with score data
   - Skins fields default to 0 to prevent disruption
+  - No error is thrown to the user
+
+### Side Bet Integration
+This endpoint includes **real-time side bet summaries** for comprehensive financial tracking:
+
+- **Real-time Calculation**: Side bet data is calculated dynamically based on current bet status
+  - `sideBetsWon` shows number of side bets won by each player
+  - `sideBetsNetGain` displays net profit/loss from all side bets
+  - `overallNetGain` combines skins and side bet gains for total financial picture
+  - Calculations include both completed and active side bets
+  - Winner determination is based on current bet declarations
+
+- **Graceful Degradation**: If side bet calculation encounters issues:
+  - Leaderboard continues to function with score and skins data
+  - Side bet fields default to 0 to prevent disruption
   - No error is thrown to the user
 
 ### Real-time Usage

--- a/docs/rounddevplan.md
+++ b/docs/rounddevplan.md
@@ -889,14 +889,18 @@ do #### Step 4.2: Side Bets **🎯 LIST ENDPOINT IN PROGRESS**
   - [ ] **Bet Types**: "hole" bets resolved during/after specific hole, "round" bets resolved at end
   - [ ] **Frontend Resolution**: Frontend can automatically prompt for winners based on betType timing
 
-- [ ] **Integration Updates** 🎯 **NEXT PRIORITY**
-  - [ ] Update `GET /api/rounds/:id/leaderboard` to include side bet wins summary
-    - [ ] **Approach**: Integrate existing `sideBetsListService` data into leaderboard response
-    - [ ] Add `sideBetsWon` count per player (from `playerSummary.betCount`)
-    - [ ] Add `sideBetsNetGain` financial summary (from `playerSummary.total`) 
-    - [ ] Add `overallNetGain` combining skins + side bets for comprehensive financial view
-    - [ ] Update leaderboard service and documentation
-    - [ ] **Implementation Note**: Use existing financial tracking from list service, no new calculation needed
+- ✅ **Integration Updates** ✅ **COMPLETED**
+  - ✅ Update `GET /api/rounds/:id/leaderboard` to include side bet wins summary
+    - ✅ **Service Integration**: Enhanced `rounds.getLeaderboard.service.js` with `sideBetsListService` integration
+    - ✅ Add `sideBetsWon` count per player (counts actual wins, not total bet participation)
+    - ✅ Add `sideBetsNetGain` financial summary (from `playerSummary.total`) 
+    - ✅ Add `overallNetGain` combining skins + side bets for comprehensive financial view
+    - ✅ **TDD Implementation**: Complete unit test coverage (14 tests) with thin slice approach
+    - ✅ **Integration Testing**: All integration tests passing (7 leaderboard tests)
+    - ✅ **Documentation Updated**: `/docs/api/rounds/GET_rounds_id_leaderboard.md` with new fields
+    - ✅ **Graceful Error Handling**: Continues working if side bet service fails (fallback to 0 values)
+    - ✅ **Real-time Calculation**: Dynamic side bet data based on current bet status and declarations
+    - ✅ **Production Ready**: All linting passed, comprehensive error handling, proper field validation
 
 #### Step 4.3: Betting Analytics
 - [ ] Betting history tracking
@@ -1008,7 +1012,12 @@ do #### Step 4.2: Side Bets **🎯 LIST ENDPOINT IN PROGRESS**
 ### Scoring  
 - ✅ `POST /api/rounds/:id/scores` - Submit/update scores (batch API, no par field, supports retroactive edits) ✅ **COMPLETED**
 - ✅ `GET /api/rounds/:id/scores` - Get all scores in matrix format (dynamic par lookup) ✅ **COMPLETED**
-- ✅ `GET /api/rounds/:id/leaderboard` - Real-time leaderboard with live skins integration ✅ **COMPLETED**
+- ✅ `GET /api/rounds/:id/leaderboard` - Real-time leaderboard with live skins and side bet integration ✅ **COMPLETED**
+  - **Response:** Player rankings with comprehensive financial tracking including skins and side bet summaries
+  - **Integration:** Real-time calculation of `sideBetsWon`, `sideBetsNetGain`, and `overallNetGain` fields
+  - **Security:** Graceful error handling, participant-only access, complete input validation
+  - **Data:** Dynamic calculation based on current scores, skins results, and side bet declarations
+  - **Documentation:** `/docs/api/rounds/GET_rounds_id_leaderboard.md` - Complete with side bet field examples
 
 ### Betting
 - ✅ `GET /api/rounds/:id/skins` - Get current skins results with carry-over tracking ✅ **COMPLETED**


### PR DESCRIPTION
✅ Updated Round Development Plan Status

  Phase 4: Step 4.2 - Integration Updates

  - ✅ COMPLETED: Full leaderboard side bet integration
  - ✅ Service Integration: Enhanced leaderboard service with side bet data
  - ✅ New Fields: sideBetsWon, sideBetsNetGain, overallNetGain
  - ✅ TDD Implementation: Complete unit test coverage (14 tests)
  - ✅ Integration Testing: All tests passing
  - ✅ Documentation: Updated API docs with examples
  - ✅ Production Ready: Linting passed, error handling, validation

  API Endpoints Section

  - ✅ Updated: GET /api/rounds/:id/leaderboard description
  - ✅ Added: Comprehensive details about side bet integration
  - ✅ Documented: Real-time calculation capabilities and security features

  The Round Development Plan now accurately reflects that Phase 4.2 Integration Updates is complete and the leaderboard endpoint provides full
  financial tracking across both skins games and side bets!

  Next Priority in the plan would be Step 4.3: Betting Analytics for advanced betting history and statistics features.

> give me a PR description for all our changes

⏺ 🎯 Feature: Leaderboard Side Bet Integration

  Summary

  Enhanced the GET /api/rounds/:id/leaderboard endpoint with comprehensive side bet integration, providing players with real-time financial tracking
  across both skins games and side bets in a single unified view.

  🚀 What's New

  New Leaderboard Fields

  - sideBetsWon - Count of side bets won by each player
  - sideBetsNetGain - Net profit/loss from all side bets
  - overallNetGain - Combined financial summary (skins + side bets)

  Real-time Integration

  - Dynamic side bet calculation using existing sideBetsListService
  - Proper winner counting logic (actual wins vs total participation)
  - Graceful error handling with fallback to default values
  - Combined financial view for comprehensive round tracking

  📋 Changes Made

  Service Layer

  - Enhanced: services/rounds.getLeaderboard.service.js
    - Added sideBetsListService integration
    - Implemented winner counting logic for side bets
    - Added financial calculation combining skins + side bets
    - Maintained graceful error handling for service failures

  Testing

  - Added: 3 new unit tests covering side bet integration scenarios
  - Updated: All existing tests to expect new response fields
  - Coverage: 14 total unit tests, all passing
  - Integration: 7 integration tests, all passing

  Documentation

  - Updated: /docs/api/rounds/GET_rounds_id_leaderboard.md
    - Added field descriptions for all new side bet fields
    - Updated response examples with realistic data
    - Added side bet integration notes and error handling info
    - Fixed existing documentation inconsistencies
  - Updated: /docs/rounddevplan.md
    - Marked Phase 4.2 Integration Updates as COMPLETED
    - Added comprehensive implementation details
    - Updated API endpoints overview section

  🔧 Technical Details

  Implementation Approach

  - TDD: Followed test-driven development with thin slices
  - Service Integration: Leveraged existing sideBetsListService for data
  - Error Resilience: Continues working if side bet service fails
  - Performance: Real-time calculation with minimal overhead

  Data Flow

  1. Fetch existing skins data (if enabled)
  2. Fetch side bet data via sideBetsListService
  3. Calculate side bet wins by checking isWinner status
  4. Combine financial data from both sources
  5. Return unified player objects with comprehensive tracking

  Winner Logic

  // Count actual wins (not total bet participation)
  sideBetsWon = sideBetsData.sideBets.filter((bet) =>
    bet.participants.some((p) => p.playerId === player.playerId && p.isWinner)
  ).length;

  📊 Response Format Changes

  Before

  {
    "playerId": "uuid",
    "position": 1,
    "skinsWon": 2,
    "total": 5.00
  }

  After

  {
    "playerId": "uuid",
    "position": 1,
    "skinsWon": 2,
    "total": 5.00,
    "sideBetsWon": 1,
    "sideBetsNetGain": 25.00,
    "overallNetGain": 30.00
  }

  ✅ Quality Assurance

  - Linting: All ESLint rules passed
  - Unit Tests: 14/14 passing (961 total across codebase)
  - Integration Tests: 7/7 leaderboard tests passing
  - Error Handling: Graceful degradation tested
  - Documentation: Complete with examples and field descriptions
  - TDD: Red-Green-Refactor cycle followed throughout

  🎯 Business Impact

  - Enhanced UX: Players see complete financial picture in one view
  - Real-time Tracking: Immediate visibility into side bet performance
  - Unified Interface: No need to check multiple endpoints for financial data
  - Robust Implementation: Continues working even if side bet features fail

  🔄 Backward Compatibility

  - ✅ Fully Compatible: All existing fields maintained
  - ✅ Additive Changes: Only new fields added, no breaking changes
  - ✅ Default Values: New fields default to 0 when no side bet data available
  - ✅ Graceful Degradation: Works with or without side bet functionality

  📝 Testing Instructions

  1. Create a round with side bets
  2. Declare winners for some side bets
  3. Call GET /api/rounds/:id/leaderboard
  4. Verify new fields are present and accurate
  5. Test error scenarios (side bet service failure)
